### PR TITLE
Constraint Ingestion

### DIFF
--- a/constraintguard/parsers/__init__.py
+++ b/constraintguard/parsers/__init__.py
@@ -1,0 +1,12 @@
+from constraintguard.parsers.constraint_loader import load_constraints
+from constraintguard.parsers.linker_script_parser import parse_linker_script
+from constraintguard.parsers.normalization import parse_size_to_bytes, parse_time_to_us
+from constraintguard.parsers.yaml_parser import parse_yaml_constraints
+
+__all__ = [
+    "load_constraints",
+    "parse_linker_script",
+    "parse_size_to_bytes",
+    "parse_time_to_us",
+    "parse_yaml_constraints",
+]

--- a/constraintguard/parsers/constraint_loader.py
+++ b/constraintguard/parsers/constraint_loader.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+from constraintguard.models import ConstraintProvenance, HardwareSpec
+from constraintguard.parsers.linker_script_parser import parse_linker_script
+from constraintguard.parsers.yaml_parser import parse_yaml_constraints
+
+_HARDWARE_SPEC_FIELDS: list[str] = [
+    "platform",
+    "ram_size_bytes",
+    "flash_size_bytes",
+    "stack_size_bytes",
+    "heap_size_bytes",
+    "max_interrupt_latency_us",
+    "critical_functions",
+    "safety_level",
+]
+
+
+def load_constraints(
+    config_path: Path | None,
+    linker_script_path: Path | None,
+) -> tuple[HardwareSpec, ConstraintProvenance]:
+    if config_path is None and linker_script_path is None:
+        raise ValueError(
+            "At least one constraint source is required: --config or a linker script path."
+        )
+
+    merged_spec_fields: dict[str, object] = {}
+    merged_origins: dict[str, object] = {}
+
+    if linker_script_path is not None:
+        ld_spec, ld_provenance = parse_linker_script(linker_script_path)
+        _apply_spec_fields(ld_spec, ld_provenance, merged_spec_fields, merged_origins)
+
+    if config_path is not None:
+        yaml_spec, yaml_provenance = parse_yaml_constraints(config_path)
+        _apply_spec_fields(yaml_spec, yaml_provenance, merged_spec_fields, merged_origins)
+
+    return (
+        HardwareSpec(**merged_spec_fields),
+        ConstraintProvenance(field_origins=merged_origins),
+    )
+
+
+def _apply_spec_fields(
+    spec: HardwareSpec,
+    provenance: ConstraintProvenance,
+    target_fields: dict[str, object],
+    target_origins: dict[str, object],
+) -> None:
+    for field in _HARDWARE_SPEC_FIELDS:
+        value = getattr(spec, field)
+        empty_list = isinstance(value, list) and len(value) == 0
+        if value is not None and not empty_list:
+            target_fields[field] = value
+            if field in provenance.field_origins:
+                target_origins[field] = provenance.field_origins[field]

--- a/constraintguard/parsers/linker_script_parser.py
+++ b/constraintguard/parsers/linker_script_parser.py
@@ -1,0 +1,131 @@
+import re
+from pathlib import Path
+
+from constraintguard.models import (
+    ConstraintProvenance,
+    ConstraintSourceType,
+    FieldProvenance,
+    HardwareSpec,
+)
+from constraintguard.parsers.normalization import parse_size_to_bytes
+
+_MEMORY_BLOCK_PATTERN = re.compile(
+    r"MEMORY\s*\{([^}]*)\}",
+    re.IGNORECASE | re.DOTALL,
+)
+
+_MEMORY_REGION_PATTERN = re.compile(
+    r"(\w+)\s*\([^)]*\)\s*:\s*ORIGIN\s*=\s*[^,]+,\s*LENGTH\s*=\s*(\S+)",
+    re.IGNORECASE,
+)
+
+_STACK_SYMBOL_PATTERN = re.compile(
+    r"(?:PROVIDE\s*\(\s*)?_+stack_size\s*=\s*(0x[0-9a-fA-F]+|\d+)\s*;",
+    re.IGNORECASE,
+)
+
+_HEAP_SYMBOL_PATTERN = re.compile(
+    r"(?:PROVIDE\s*\(\s*)?_+heap_size\s*=\s*(0x[0-9a-fA-F]+|\d+)\s*;",
+    re.IGNORECASE,
+)
+
+_RAM_NAME_PATTERN = re.compile(r"ram|sram|dtcm|ccm", re.IGNORECASE)
+_FLASH_NAME_PATTERN = re.compile(r"flash|rom|nor", re.IGNORECASE)
+
+
+def parse_linker_script(ld_path: Path) -> tuple[HardwareSpec, ConstraintProvenance]:
+    if not ld_path.exists():
+        raise FileNotFoundError(f"Linker script not found: {ld_path}")
+
+    source_content = _read_and_strip_comments(ld_path)
+    source_path_str = str(ld_path)
+    spec_fields: dict[str, object] = {}
+    field_origins: dict[str, FieldProvenance] = {}
+
+    ram_bytes, flash_bytes = _extract_memory_regions(source_content, ld_path)
+
+    if ram_bytes is not None:
+        spec_fields["ram_size_bytes"] = ram_bytes
+        field_origins["ram_size_bytes"] = FieldProvenance(
+            source_type=ConstraintSourceType.LINKER_SCRIPT,
+            source_path=source_path_str,
+            extraction_note="Extracted from MEMORY block RAM regions",
+        )
+
+    if flash_bytes is not None:
+        spec_fields["flash_size_bytes"] = flash_bytes
+        field_origins["flash_size_bytes"] = FieldProvenance(
+            source_type=ConstraintSourceType.LINKER_SCRIPT,
+            source_path=source_path_str,
+            extraction_note="Extracted from MEMORY block FLASH regions",
+        )
+
+    stack_bytes = _extract_symbol_value(_STACK_SYMBOL_PATTERN, source_content)
+    if stack_bytes is not None:
+        spec_fields["stack_size_bytes"] = stack_bytes
+        field_origins["stack_size_bytes"] = FieldProvenance(
+            source_type=ConstraintSourceType.LINKER_SCRIPT,
+            source_path=source_path_str,
+            extraction_note="Extracted from _stack_size symbol",
+        )
+
+    heap_bytes = _extract_symbol_value(_HEAP_SYMBOL_PATTERN, source_content)
+    if heap_bytes is not None:
+        spec_fields["heap_size_bytes"] = heap_bytes
+        field_origins["heap_size_bytes"] = FieldProvenance(
+            source_type=ConstraintSourceType.LINKER_SCRIPT,
+            source_path=source_path_str,
+            extraction_note="Extracted from _heap_size symbol",
+        )
+
+    return HardwareSpec(**spec_fields), ConstraintProvenance(field_origins=field_origins)
+
+
+def _read_and_strip_comments(ld_path: Path) -> str:
+    raw = ld_path.read_text(encoding="utf-8")
+    without_block_comments = re.sub(r"/\*.*?\*/", " ", raw, flags=re.DOTALL)
+    without_line_comments = re.sub(r"//[^\n]*", " ", without_block_comments)
+    return without_line_comments
+
+
+def _extract_memory_regions(
+    source: str, ld_path: Path
+) -> tuple[int | None, int | None]:
+    memory_block_match = _MEMORY_BLOCK_PATTERN.search(source)
+    if not memory_block_match:
+        return None, None
+
+    block_content = memory_block_match.group(1)
+    ram_total = 0
+    flash_total = 0
+    found_ram = False
+    found_flash = False
+
+    for region_match in _MEMORY_REGION_PATTERN.finditer(block_content):
+        region_name = region_match.group(1)
+        length_str = region_match.group(2).rstrip(",;")
+
+        try:
+            region_bytes = parse_size_to_bytes(length_str)
+        except ValueError:
+            continue
+
+        if _RAM_NAME_PATTERN.search(region_name):
+            ram_total += region_bytes
+            found_ram = True
+        elif _FLASH_NAME_PATTERN.search(region_name):
+            flash_total += region_bytes
+            found_flash = True
+
+    return (ram_total if found_ram else None), (flash_total if found_flash else None)
+
+
+def _extract_symbol_value(pattern: re.Pattern[str], source: str) -> int | None:
+    match = pattern.search(source)
+    if not match:
+        return None
+    raw_value = match.group(1)
+    try:
+        return parse_size_to_bytes(raw_value)
+    except ValueError:
+        return None

--- a/constraintguard/parsers/normalization.py
+++ b/constraintguard/parsers/normalization.py
@@ -1,0 +1,59 @@
+import re
+from decimal import Decimal
+
+_SIZE_PATTERN = re.compile(
+    r"^\s*(\d+(?:\.\d+)?)\s*(B|KB|MB|GB|K|M|G)?\s*$",
+    re.IGNORECASE,
+)
+
+_TIME_PATTERN = re.compile(
+    r"^\s*(\d+(?:\.\d+)?)\s*(us|ms|s)\s*$",
+    re.IGNORECASE,
+)
+
+_SIZE_MULTIPLIERS: dict[str, int] = {
+    "b": 1,
+    "kb": 1024,
+    "mb": 1024**2,
+    "gb": 1024**3,
+    "k": 1024,
+    "m": 1024**2,
+    "g": 1024**3,
+}
+
+_TIME_MULTIPLIERS: dict[str, int] = {
+    "us": 1,
+    "ms": 1_000,
+    "s": 1_000_000,
+}
+
+
+def parse_size_to_bytes(value: str | int) -> int:
+    if isinstance(value, int):
+        return value
+    stripped = str(value).strip()
+    if stripped.lower().startswith("0x"):
+        return int(stripped, 16)
+    match = _SIZE_PATTERN.match(stripped)
+    if not match:
+        raise ValueError(
+            f"Cannot parse size value: {value!r}. "
+            "Expected format: '2KB', '256K', '1MB', or plain integer bytes."
+        )
+    number = Decimal(match.group(1))
+    unit = (match.group(2) or "b").lower()
+    return int(number * _SIZE_MULTIPLIERS[unit])
+
+
+def parse_time_to_us(value: str | int) -> int:
+    if isinstance(value, int):
+        return value
+    match = _TIME_PATTERN.match(str(value).strip())
+    if not match:
+        raise ValueError(
+            f"Cannot parse time value: {value!r}. "
+            "Expected format: '50us', '100ms', '1s', or plain integer (microseconds)."
+        )
+    number = Decimal(match.group(1))
+    unit = match.group(2).lower()
+    return int(number * _TIME_MULTIPLIERS[unit])

--- a/constraintguard/parsers/yaml_parser.py
+++ b/constraintguard/parsers/yaml_parser.py
@@ -1,0 +1,117 @@
+from pathlib import Path
+
+import yaml
+
+from constraintguard.models import (
+    ConstraintProvenance,
+    ConstraintSourceType,
+    FieldProvenance,
+    HardwareSpec,
+)
+from constraintguard.parsers.normalization import parse_size_to_bytes, parse_time_to_us
+
+_YAML_SIZE_FIELDS: dict[str, str] = {
+    "ram_size": "ram_size_bytes",
+    "flash_size": "flash_size_bytes",
+    "stack_size": "stack_size_bytes",
+    "heap_size": "heap_size_bytes",
+}
+
+_YAML_TIME_FIELDS: dict[str, str] = {
+    "max_interrupt_latency": "max_interrupt_latency_us",
+}
+
+_YAML_SCALAR_FIELDS: list[str] = ["platform", "safety_level"]
+
+_YAML_LIST_FIELDS: list[str] = ["critical_functions"]
+
+
+def parse_yaml_constraints(config_path: Path) -> tuple[HardwareSpec, ConstraintProvenance]:
+    if not config_path.exists():
+        raise FileNotFoundError(f"Constraint config not found: {config_path}")
+
+    raw = _load_yaml_file(config_path)
+    source_path_str = str(config_path)
+    field_origins: dict[str, FieldProvenance] = {}
+    spec_fields: dict[str, object] = {}
+
+    for yaml_key, spec_key in _YAML_SIZE_FIELDS.items():
+        raw_value = raw.get(yaml_key)
+        if raw_value is not None:
+            spec_fields[spec_key] = _parse_size_field(yaml_key, raw_value)
+            field_origins[spec_key] = FieldProvenance(
+                source_type=ConstraintSourceType.YAML,
+                source_path=source_path_str,
+                extraction_note=f"Parsed from '{yaml_key}' field",
+            )
+
+    for yaml_key, spec_key in _YAML_TIME_FIELDS.items():
+        raw_value = raw.get(yaml_key)
+        if raw_value is not None:
+            spec_fields[spec_key] = _parse_time_field(yaml_key, raw_value)
+            field_origins[spec_key] = FieldProvenance(
+                source_type=ConstraintSourceType.YAML,
+                source_path=source_path_str,
+                extraction_note=f"Parsed from '{yaml_key}' field",
+            )
+
+    for field in _YAML_SCALAR_FIELDS:
+        raw_value = raw.get(field)
+        if raw_value is not None:
+            spec_fields[field] = str(raw_value)
+            field_origins[field] = FieldProvenance(
+                source_type=ConstraintSourceType.YAML,
+                source_path=source_path_str,
+            )
+
+    for field in _YAML_LIST_FIELDS:
+        raw_value = raw.get(field)
+        if raw_value is not None:
+            spec_fields[field] = _parse_string_list(field, raw_value)
+            field_origins[field] = FieldProvenance(
+                source_type=ConstraintSourceType.YAML,
+                source_path=source_path_str,
+            )
+
+    return HardwareSpec(**spec_fields), ConstraintProvenance(field_origins=field_origins)
+
+
+def _load_yaml_file(config_path: Path) -> dict:
+    with config_path.open("r", encoding="utf-8") as fh:
+        content = yaml.safe_load(fh)
+    if not isinstance(content, dict):
+        raise ValueError(
+            f"Constraint config must be a YAML mapping at the top level: {config_path}"
+        )
+    return content
+
+
+def _parse_size_field(field_name: str, raw_value: object) -> int:
+    try:
+        return parse_size_to_bytes(raw_value)  # type: ignore[arg-type]
+    except (ValueError, TypeError) as exc:
+        raise ValueError(
+            f"Invalid value for '{field_name}': {raw_value!r}. {exc}"
+        ) from exc
+
+
+def _parse_time_field(field_name: str, raw_value: object) -> int:
+    try:
+        return parse_time_to_us(raw_value)  # type: ignore[arg-type]
+    except (ValueError, TypeError) as exc:
+        raise ValueError(
+            f"Invalid value for '{field_name}': {raw_value!r}. {exc}"
+        ) from exc
+
+
+def _parse_string_list(field_name: str, raw_value: object) -> list[str]:
+    if not isinstance(raw_value, list):
+        raise ValueError(
+            f"Field '{field_name}' must be a YAML list of strings, got: {type(raw_value).__name__}"
+        )
+    for item in raw_value:
+        if not isinstance(item, str):
+            raise ValueError(
+                f"All entries in '{field_name}' must be strings, found: {item!r}"
+            )
+    return raw_value

--- a/examples/configs/relaxed.yml
+++ b/examples/configs/relaxed.yml
@@ -1,0 +1,11 @@
+platform: "cortex-a53"
+
+ram_size: "512MB"
+flash_size: "4GB"
+stack_size: "8MB"
+heap_size: "64MB"
+max_interrupt_latency: "1ms"
+
+safety_level: "IEC62443-SL1"
+critical_functions:
+  - "auth_handler"

--- a/examples/configs/tight.yml
+++ b/examples/configs/tight.yml
@@ -1,0 +1,13 @@
+platform: "cortex-m4"
+
+ram_size: "20KB"
+flash_size: "256KB"
+stack_size: "2KB"
+heap_size: "4KB"
+max_interrupt_latency: "50us"
+
+safety_level: "ISO26262-ASIL-B"
+critical_functions:
+  - "control_loop"
+  - "isr_uart"
+  - "watchdog_feed"

--- a/examples/vuln_demo/linker.ld
+++ b/examples/vuln_demo/linker.ld
@@ -1,0 +1,42 @@
+/* Example linker script for a Cortex-M4 target (vuln_demo) */
+
+_stack_size = 0x800;  /* 2KB stack */
+_heap_size  = 0x1000; /* 4KB heap  */
+
+MEMORY
+{
+    FLASH (rx)  : ORIGIN = 0x08000000, LENGTH = 256K
+    RAM   (rwx) : ORIGIN = 0x20000000, LENGTH = 20K
+}
+
+SECTIONS
+{
+    .text :
+    {
+        *(.text*)
+    } > FLASH
+
+    .data :
+    {
+        *(.data*)
+    } > RAM AT > FLASH
+
+    .bss :
+    {
+        *(.bss*)
+    } > RAM
+
+    ._stack (NOLOAD) :
+    {
+        . = ALIGN(8);
+        . = . + _stack_size;
+        . = ALIGN(8);
+    } > RAM
+
+    ._heap (NOLOAD) :
+    {
+        . = ALIGN(8);
+        . = . + _heap_size;
+        . = ALIGN(8);
+    } > RAM
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ description = "Constraint-aware security prioritization for embedded C/C++ proje
 requires-python = ">=3.10"
 dependencies = [
     "pydantic>=2.0",
+    "pyyaml>=6.0",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pydantic>=2.0
+pyyaml>=6.0


### PR DESCRIPTION
Closes #3 

## What Changed

### Normalization Layer
- **`parsers/normalization.py`** — two pure functions shared across all parsers
  - `parse_size_to_bytes`: accepts `B/KB/MB/GB`, `K/M/G` shorthand, `0x` hex, and plain ints
  - `parse_time_to_us`: accepts `us/ms/s` and plain ints
  - Both raise `ValueError` with a clear message on invalid input — no silent coercion

### YAML Constraint Parser
- **`parsers/yaml_parser.py`** — reads `.constraintguard.yml`
  - Handles: `platform`, `safety_level`, `critical_functions`, size fields (`ram_size`, `flash_size`, `stack_size`, `heap_size`), and time field (`max_interrupt_latency`)
  - Each parsed field records `FieldProvenance(source_type=YAML, source_path, extraction_note)`
  - Rejects non-dict top-level YAML and malformed values loudly

### Linker Script Parser
- **`parsers/linker_script_parser.py`** — extracts constraints from `.ld` files
  - Strips `/* */` and `//` comments before parsing
  - Parses `MEMORY { }` block: matches region names against `ram/sram/dtcm/ccm` and `flash/rom/nor` patterns; sums multiple matching regions
  - Extracts `_stack_size` and `_heap_size` symbols (supports both hex and decimal, with or without `PROVIDE`)
  - Records `FieldProvenance(source_type=LINKER_SCRIPT)` per extracted field
  - Silently skips unparseable regions rather than crashing the run

### Constraint Loader (Merge)
- **`parsers/constraint_loader.py`** — `load_constraints(config_path, linker_script_path)`
  - Runs linker script first, then YAML on top — explicit user values always win
  - Returns merged `HardwareSpec` + `ConstraintProvenance`
  - Raises if both sources are `None`

### Example Assets
- **tight.yml** — Cortex-M4, 20KB RAM, 2KB stack, ASIL-B
- **relaxed.yml** — Cortex-A53, 512MB RAM, 8MB stack, IEC62443-SL1
- **linker.ld** — minimal linker script matching the tight profile (used by mock_pipeline.py)