### PR TITLE
SARIF parser with rule/CWE mapping (Task D4)

### DIFF
--- a/constraintguard/analyzers/__init__.py
+++ b/constraintguard/analyzers/__init__.py
@@ -1,0 +1,13 @@
+from constraintguard.analyzers.scan_build_runner import (
+    AnalyzerError,
+    ScanBuildConfig,
+    ScanBuildResult,
+    run_scan_build,
+)
+
+__all__ = [
+    "AnalyzerError",
+    "ScanBuildConfig",
+    "ScanBuildResult",
+    "run_scan_build",
+]

--- a/constraintguard/analyzers/scan_build_runner.py
+++ b/constraintguard/analyzers/scan_build_runner.py
@@ -1,0 +1,81 @@
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+
+from pydantic import BaseModel
+
+
+class AnalyzerError(Exception):
+    pass
+
+
+class ScanBuildConfig(BaseModel):
+    source_path: Path
+    build_command: str
+    output_dir: Path
+
+    model_config = {"arbitrary_types_allowed": True}
+
+
+class ScanBuildResult(BaseModel):
+    sarif_paths: list[Path]
+    exit_code: int
+    sarif_dir: Path
+
+    model_config = {"arbitrary_types_allowed": True}
+
+
+def run_scan_build(config: ScanBuildConfig) -> ScanBuildResult:
+    _require_scan_build_on_path()
+    sarif_dir = _prepare_sarif_output_dir(config.output_dir)
+    command = _build_scan_build_command(sarif_dir, config.build_command)
+    exit_code = _execute_command(command)
+    sarif_paths = _collect_sarif_files(sarif_dir)
+    return ScanBuildResult(
+        sarif_paths=sarif_paths,
+        exit_code=exit_code,
+        sarif_dir=sarif_dir,
+    )
+
+
+def _require_scan_build_on_path() -> None:
+    if shutil.which("scan-build") is None:
+        raise AnalyzerError(
+            "scan-build not found on PATH. "
+            "Install Clang/LLVM and ensure scan-build is accessible."
+        )
+
+
+def _prepare_sarif_output_dir(output_dir: Path) -> Path:
+    sarif_dir = output_dir / "sarif"
+    if sarif_dir.exists():
+        shutil.rmtree(sarif_dir)
+    sarif_dir.mkdir(parents=True)
+    return sarif_dir
+
+
+def _build_scan_build_command(sarif_dir: Path, build_command: str) -> list[str]:
+    build_parts = shlex.split(build_command)
+    return [
+        "scan-build",
+        "-o", str(sarif_dir),
+        "-Xanalyzer", "-analyzer-output",
+        "-Xanalyzer", "sarif",
+        *build_parts,
+    ]
+
+
+def _execute_command(command: list[str]) -> int:
+    result = subprocess.run(command)
+    if result.returncode != 0:
+        raise AnalyzerError(
+            f"scan-build exited with non-zero code {result.returncode}. "
+            f"Verify the build command succeeds independently before running through scan-build. "
+            f"Full command: {' '.join(command)}"
+        )
+    return result.returncode
+
+
+def _collect_sarif_files(sarif_dir: Path) -> list[Path]:
+    return sorted(sarif_dir.rglob("*.sarif"))

--- a/constraintguard/models/__init__.py
+++ b/constraintguard/models/__init__.py
@@ -4,6 +4,7 @@ from constraintguard.models.enums import (
     MEDIUM_THRESHOLD,
     ConstraintSourceType,
     SeverityTier,
+    VulnerabilityCategory,
     score_to_tier,
 )
 from constraintguard.models.hardware_spec import (
@@ -37,5 +38,6 @@ __all__ = [
     "SeverityTier",
     "TierCounts",
     "Vulnerability",
+    "VulnerabilityCategory",
     "score_to_tier",
 ]

--- a/constraintguard/models/enums.py
+++ b/constraintguard/models/enums.py
@@ -19,6 +19,19 @@ class ConstraintSourceType(Enum):
     UNKNOWN = "unknown"
 
 
+class VulnerabilityCategory(Enum):
+    BUFFER_OVERFLOW = "buffer_overflow"
+    NULL_DEREF = "null_deref"
+    LEAK = "leak"
+    USE_AFTER_FREE = "use_after_free"
+    INTEGER_OVERFLOW = "integer_overflow"
+    FORMAT_STRING = "format_string"
+    DIVIDE_BY_ZERO = "divide_by_zero"
+    UNINITIALIZED = "uninitialized"
+    DEADLOCK = "deadlock"
+    UNKNOWN = "unknown"
+
+
 def score_to_tier(score: int) -> SeverityTier:
     if score >= CRITICAL_THRESHOLD:
         return SeverityTier.CRITICAL

--- a/constraintguard/parsers/__init__.py
+++ b/constraintguard/parsers/__init__.py
@@ -1,11 +1,13 @@
 from constraintguard.parsers.constraint_loader import load_constraints
 from constraintguard.parsers.linker_script_parser import parse_linker_script
 from constraintguard.parsers.normalization import parse_size_to_bytes, parse_time_to_us
+from constraintguard.parsers.sarif_parser import parse_sarif
 from constraintguard.parsers.yaml_parser import parse_yaml_constraints
 
 __all__ = [
     "load_constraints",
     "parse_linker_script",
+    "parse_sarif",
     "parse_size_to_bytes",
     "parse_time_to_us",
     "parse_yaml_constraints",

--- a/constraintguard/parsers/sarif_parser.py
+++ b/constraintguard/parsers/sarif_parser.py
@@ -1,0 +1,237 @@
+import json
+import logging
+from pathlib import Path
+
+from constraintguard.models.vulnerability import Vulnerability
+from constraintguard.parsers.sarif_rule_map import (
+    VulnerabilityCategory,
+    resolve_category,
+    resolve_cwe,
+)
+
+logger = logging.getLogger(__name__)
+
+_CWE_TAG_PREFIX = "CWE-"
+
+
+def parse_sarif(sarif_path: Path) -> list[Vulnerability]:
+    raw = _load_sarif(sarif_path)
+    runs = raw.get("runs", [])
+
+    vulnerabilities: list[Vulnerability] = []
+    for run in runs:
+        if not isinstance(run, dict):
+            logger.warning("Skipping non-dict run entry in %s", sarif_path)
+            continue
+        tool_name = _extract_tool_name(run)
+        rule_cwe_registry = _build_rule_cwe_registry(run)
+        run_vulns = _parse_run(run, tool_name, rule_cwe_registry, sarif_path)
+        vulnerabilities.extend(run_vulns)
+
+    return vulnerabilities
+
+
+def _load_sarif(sarif_path: Path) -> dict:
+    if not sarif_path.exists():
+        raise FileNotFoundError(f"SARIF file not found: {sarif_path}")
+    with sarif_path.open("r", encoding="utf-8") as fh:
+        content = json.load(fh)
+    if not isinstance(content, dict):
+        raise ValueError(f"SARIF file must contain a JSON object at the top level: {sarif_path}")
+    return content
+
+
+def _extract_tool_name(run: dict) -> str:
+    try:
+        return run["tool"]["driver"]["name"]
+    except (KeyError, TypeError):
+        return "unknown"
+
+
+def _build_rule_cwe_registry(run: dict) -> dict[str, str]:
+    registry: dict[str, str] = {}
+    try:
+        rules = run["tool"]["driver"].get("rules", [])
+    except (KeyError, TypeError):
+        return registry
+
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        rule_id = rule.get("id")
+        if not rule_id:
+            continue
+        cwe = _extract_cwe_from_rule_definition(rule)
+        if cwe:
+            registry[rule_id] = cwe
+
+    return registry
+
+
+def _extract_cwe_from_rule_definition(rule: dict) -> str | None:
+    cwe_from_tags = _extract_cwe_from_tags(rule.get("properties", {}).get("tags", []))
+    if cwe_from_tags:
+        return cwe_from_tags
+
+    for relationship in rule.get("relationships", []):
+        try:
+            component_name = relationship["target"]["toolComponent"]["name"]
+            if component_name.upper() == "CWE":
+                cwe_id = relationship["target"]["id"]
+                return f"CWE-{cwe_id}"
+        except (KeyError, TypeError):
+            continue
+
+    return None
+
+
+def _parse_run(
+    run: dict,
+    tool_name: str,
+    rule_cwe_registry: dict[str, str],
+    sarif_path: Path,
+) -> list[Vulnerability]:
+    results = run.get("results", [])
+    vulnerabilities: list[Vulnerability] = []
+
+    for index, result in enumerate(results):
+        try:
+            vuln = _parse_result(result, tool_name, rule_cwe_registry)
+            if vuln is not None:
+                vulnerabilities.append(vuln)
+        except Exception as exc:
+            logger.warning(
+                "Skipping malformed SARIF result at index %d in %s: %s",
+                index,
+                sarif_path,
+                exc,
+            )
+
+    return vulnerabilities
+
+
+def _parse_result(
+    result: dict,
+    tool_name: str,
+    rule_cwe_registry: dict[str, str],
+) -> Vulnerability | None:
+    if not isinstance(result, dict):
+        return None
+
+    rule_id = _extract_rule_id(result)
+    if not rule_id:
+        return None
+
+    message = _extract_message(result)
+    if not message:
+        return None
+
+    locations = result.get("locations", [])
+    path, start_line, start_col = _extract_physical_location(locations)
+    function_name = _extract_function_name(locations)
+
+    category = resolve_category(rule_id)
+    cwe = _extract_cwe_from_result(result, rule_id, rule_cwe_registry, category)
+
+    return Vulnerability(
+        tool=tool_name,
+        rule_id=rule_id,
+        message=message,
+        path=path,
+        start_line=start_line,
+        start_col=start_col,
+        function=function_name,
+        cwe=cwe,
+        category=category.value,
+    )
+
+
+def _extract_rule_id(result: dict) -> str | None:
+    rule_id = result.get("ruleId")
+    if rule_id:
+        return rule_id
+    try:
+        return result["rule"]["id"]
+    except (KeyError, TypeError):
+        return None
+
+
+def _extract_message(result: dict) -> str | None:
+    message_obj = result.get("message")
+    if not isinstance(message_obj, dict):
+        return None
+    return message_obj.get("text") or message_obj.get("markdown")
+
+
+def _extract_physical_location(
+    locations: list,
+) -> tuple[str, int | None, int | None]:
+    if not locations or not isinstance(locations[0], dict):
+        return "unknown", None, None
+
+    physical = locations[0].get("physicalLocation", {})
+    if not isinstance(physical, dict):
+        return "unknown", None, None
+
+    artifact = physical.get("artifactLocation", {})
+    path = artifact.get("uri", "unknown") if isinstance(artifact, dict) else "unknown"
+
+    region = physical.get("region", {})
+    if not isinstance(region, dict):
+        return path, None, None
+
+    start_line = region.get("startLine")
+    start_col = region.get("startColumn")
+
+    return (
+        path,
+        int(start_line) if start_line is not None else None,
+        int(start_col) if start_col is not None else None,
+    )
+
+
+def _extract_function_name(locations: list) -> str | None:
+    if not locations or not isinstance(locations[0], dict):
+        return None
+
+    logical_locations = locations[0].get("logicalLocations", [])
+    if not isinstance(logical_locations, list):
+        return None
+
+    for entry in logical_locations:
+        if not isinstance(entry, dict):
+            continue
+        kind = entry.get("kind", "")
+        if kind in ("function", "method") or not kind:
+            name = entry.get("name") or entry.get("fullyQualifiedName")
+            if name:
+                return name
+
+    return None
+
+
+def _extract_cwe_from_result(
+    result: dict,
+    rule_id: str,
+    rule_cwe_registry: dict[str, str],
+    category: VulnerabilityCategory,
+) -> str | None:
+    cwe_from_props = _extract_cwe_from_tags(
+        result.get("properties", {}).get("tags", [])
+    )
+    if cwe_from_props:
+        return cwe_from_props
+
+    if rule_id in rule_cwe_registry:
+        return rule_cwe_registry[rule_id]
+
+    return resolve_cwe(rule_id, category)
+
+
+def _extract_cwe_from_tags(tags: list | None) -> str | None:
+    if not isinstance(tags, list):
+        return None
+    for tag in tags:
+        if isinstance(tag, str) and tag.upper().startswith(_CWE_TAG_PREFIX.upper()):
+            return tag.upper()
+    return None

--- a/constraintguard/parsers/sarif_rule_map.py
+++ b/constraintguard/parsers/sarif_rule_map.py
@@ -1,0 +1,133 @@
+from constraintguard.models.enums import VulnerabilityCategory
+
+_RULE_CATEGORY_MAP: dict[str, VulnerabilityCategory] = {
+    # --- Buffer overflow / out-of-bounds ---
+    "alpha.security.ArrayBoundV2": VulnerabilityCategory.BUFFER_OVERFLOW,
+    "alpha.security.ReturnPtrRange": VulnerabilityCategory.BUFFER_OVERFLOW,
+    "alpha.unix.cstring.OutOfBounds": VulnerabilityCategory.BUFFER_OVERFLOW,
+    "alpha.unix.cstring.BufferOverlap": VulnerabilityCategory.BUFFER_OVERFLOW,
+    "security.insecureAPI.strcpy": VulnerabilityCategory.BUFFER_OVERFLOW,
+    "security.insecureAPI.strcat": VulnerabilityCategory.BUFFER_OVERFLOW,
+    "security.insecureAPI.gets": VulnerabilityCategory.BUFFER_OVERFLOW,
+    "security.insecureAPI.sprintf": VulnerabilityCategory.BUFFER_OVERFLOW,
+    "security.insecureAPI.vsprintf": VulnerabilityCategory.BUFFER_OVERFLOW,
+    "security.insecureAPI.scanf": VulnerabilityCategory.BUFFER_OVERFLOW,
+    "security.insecureAPI.strncat": VulnerabilityCategory.BUFFER_OVERFLOW,
+    # --- Null dereference ---
+    "core.NullDereference": VulnerabilityCategory.NULL_DEREF,
+    "alpha.core.CastToStruct": VulnerabilityCategory.NULL_DEREF,
+    "alpha.core.NullDereference": VulnerabilityCategory.NULL_DEREF,
+    # --- Memory leaks ---
+    "unix.Malloc": VulnerabilityCategory.LEAK,
+    "cplusplus.NewDeleteLeaks": VulnerabilityCategory.LEAK,
+    "alpha.unix.MallocWithAnnotations": VulnerabilityCategory.LEAK,
+    "alpha.cplusplus.MismatchedIterator": VulnerabilityCategory.LEAK,
+    # --- Use-after-free / double-free ---
+    "cplusplus.NewDelete": VulnerabilityCategory.USE_AFTER_FREE,
+    "unix.MismatchedDeallocator": VulnerabilityCategory.USE_AFTER_FREE,
+    "alpha.cplusplus.DeleteWithNonVirtualDtor": VulnerabilityCategory.USE_AFTER_FREE,
+    # --- Integer overflow / taint ---
+    "alpha.security.taint.TaintPropagation": VulnerabilityCategory.INTEGER_OVERFLOW,
+    "alpha.security.taint.TaintPropagationChecker": VulnerabilityCategory.INTEGER_OVERFLOW,
+    # --- Format string ---
+    "security.insecureAPI.vfprintf": VulnerabilityCategory.FORMAT_STRING,
+    "security.insecureAPI.printf": VulnerabilityCategory.FORMAT_STRING,
+    # --- Divide by zero ---
+    "core.DivideZero": VulnerabilityCategory.DIVIDE_BY_ZERO,
+    # --- Uninitialized values ---
+    "core.uninitialized.Assign": VulnerabilityCategory.UNINITIALIZED,
+    "core.uninitialized.Branch": VulnerabilityCategory.UNINITIALIZED,
+    "core.uninitialized.CapturedBlockVariable": VulnerabilityCategory.UNINITIALIZED,
+    "core.uninitialized.UndefReturn": VulnerabilityCategory.UNINITIALIZED,
+    "core.uninitialized.ArraySubscript": VulnerabilityCategory.UNINITIALIZED,
+    # --- Concurrency / deadlock ---
+    "alpha.unix.PthreadLock": VulnerabilityCategory.DEADLOCK,
+    "alpha.core.CastSize": VulnerabilityCategory.INTEGER_OVERFLOW,
+}
+
+_RULE_CWE_MAP: dict[str, str] = {
+    # Buffer overflow
+    "alpha.security.ArrayBoundV2": "CWE-119",
+    "alpha.security.ReturnPtrRange": "CWE-119",
+    "alpha.unix.cstring.OutOfBounds": "CWE-119",
+    "alpha.unix.cstring.BufferOverlap": "CWE-119",
+    "security.insecureAPI.strcpy": "CWE-120",
+    "security.insecureAPI.strcat": "CWE-120",
+    "security.insecureAPI.gets": "CWE-120",
+    "security.insecureAPI.sprintf": "CWE-120",
+    "security.insecureAPI.vsprintf": "CWE-120",
+    "security.insecureAPI.scanf": "CWE-120",
+    "security.insecureAPI.strncat": "CWE-120",
+    # Null dereference
+    "core.NullDereference": "CWE-476",
+    "alpha.core.CastToStruct": "CWE-476",
+    "alpha.core.NullDereference": "CWE-476",
+    # Leaks
+    "unix.Malloc": "CWE-401",
+    "cplusplus.NewDeleteLeaks": "CWE-401",
+    "alpha.unix.MallocWithAnnotations": "CWE-401",
+    # Use-after-free
+    "cplusplus.NewDelete": "CWE-416",
+    "unix.MismatchedDeallocator": "CWE-416",
+    # Taint / integer
+    "alpha.security.taint.TaintPropagation": "CWE-190",
+    "alpha.core.CastSize": "CWE-190",
+    # Format string
+    "security.insecureAPI.vfprintf": "CWE-134",
+    "security.insecureAPI.printf": "CWE-134",
+    # Divide by zero
+    "core.DivideZero": "CWE-369",
+    # Uninitialized
+    "core.uninitialized.Assign": "CWE-457",
+    "core.uninitialized.Branch": "CWE-457",
+    "core.uninitialized.CapturedBlockVariable": "CWE-457",
+    "core.uninitialized.UndefReturn": "CWE-457",
+    "core.uninitialized.ArraySubscript": "CWE-457",
+    # Deadlock
+    "alpha.unix.PthreadLock": "CWE-833",
+}
+
+_CATEGORY_FALLBACK_CWE: dict[VulnerabilityCategory, str] = {
+    VulnerabilityCategory.BUFFER_OVERFLOW: "CWE-120",
+    VulnerabilityCategory.NULL_DEREF: "CWE-476",
+    VulnerabilityCategory.LEAK: "CWE-401",
+    VulnerabilityCategory.USE_AFTER_FREE: "CWE-416",
+    VulnerabilityCategory.INTEGER_OVERFLOW: "CWE-190",
+    VulnerabilityCategory.FORMAT_STRING: "CWE-134",
+    VulnerabilityCategory.DIVIDE_BY_ZERO: "CWE-369",
+    VulnerabilityCategory.UNINITIALIZED: "CWE-457",
+    VulnerabilityCategory.DEADLOCK: "CWE-833",
+}
+
+_PREFIX_CATEGORY_MAP: list[tuple[str, VulnerabilityCategory]] = [
+    ("core.uninitialized.", VulnerabilityCategory.UNINITIALIZED),
+    ("alpha.security.taint.", VulnerabilityCategory.INTEGER_OVERFLOW),
+    ("alpha.unix.cstring.", VulnerabilityCategory.BUFFER_OVERFLOW),
+    ("security.insecureAPI.", VulnerabilityCategory.BUFFER_OVERFLOW),
+    ("cplusplus.NewDelete", VulnerabilityCategory.USE_AFTER_FREE),
+    ("unix.Malloc", VulnerabilityCategory.LEAK),
+    ("alpha.unix.PthreadLock", VulnerabilityCategory.DEADLOCK),
+]
+
+
+def resolve_category(rule_id: str) -> VulnerabilityCategory:
+    exact = _RULE_CATEGORY_MAP.get(rule_id)
+    if exact is not None:
+        return exact
+
+    for prefix, category in _PREFIX_CATEGORY_MAP:
+        if rule_id.startswith(prefix):
+            return category
+
+    return VulnerabilityCategory.UNKNOWN
+
+
+def resolve_cwe(rule_id: str, category: VulnerabilityCategory | None = None) -> str | None:
+    exact = _RULE_CWE_MAP.get(rule_id)
+    if exact is not None:
+        return exact
+
+    if category is not None:
+        return _CATEGORY_FALLBACK_CWE.get(category)
+
+    return None

--- a/examples/vuln_demo/Makefile
+++ b/examples/vuln_demo/Makefile
@@ -1,0 +1,19 @@
+CC     ?= cc
+CFLAGS  = -Wall -Wextra -g
+
+TARGET = vuln_demo
+SRCS   = main.c
+OBJS   = $(SRCS:.c=.o)
+
+.PHONY: all clean
+
+all: $(TARGET)
+
+$(TARGET): $(OBJS)
+	$(CC) $(CFLAGS) -o $@ $^
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+clean:
+	rm -f $(TARGET) $(OBJS)

--- a/examples/vuln_demo/main.c
+++ b/examples/vuln_demo/main.c
@@ -1,0 +1,102 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/*
+ * Intentionally vulnerable patterns for ConstraintGuard demo analysis.
+ * Each function contains a detectable defect. Severity rankings change
+ * depending on whether a tight or relaxed constraint profile is applied.
+ */
+
+/* CWE-120: Buffer overflow via unsafe strcpy into fixed-size stack buffer */
+static void copy_input(const char *input)
+{
+    char buf[16];
+    strcpy(buf, input);
+    printf("input: %s\n", buf);
+}
+
+/* CWE-476: Null pointer dereference — pointer may be NULL on one path */
+static int read_sensor(int *sensor_value)
+{
+    return *sensor_value;
+}
+
+/* CWE-401: Memory leak — allocation not freed before function return */
+static char *build_packet(size_t size)
+{
+    char *packet = malloc(size);
+    if (packet == NULL) {
+        return NULL;
+    }
+    memset(packet, 0, size);
+    char *header = malloc(8);
+    if (header == NULL) {
+        /* packet leaks here */
+        return NULL;
+    }
+    memcpy(packet, header, 8);
+    free(header);
+    return packet;
+}
+
+/* CWE-416: Use after free */
+static void process_buffer(void)
+{
+    char *buf = malloc(64);
+    if (buf == NULL) {
+        return;
+    }
+    snprintf(buf, 64, "data");
+    free(buf);
+    printf("processed: %s\n", buf);
+}
+
+/* CWE-190: Integer overflow in size calculation before malloc */
+static void *allocate_matrix(int rows, int cols)
+{
+    int total = rows * cols;
+    return malloc((size_t)total);
+}
+
+/* CWE-134: Use of uninitialized value through a conditional path */
+static int compute_checksum(int mode)
+{
+    int result;
+    if (mode == 1) {
+        result = 0xDEAD;
+    }
+    return result;
+}
+
+int main(int argc, char *argv[])
+{
+    if (argc > 1) {
+        copy_input(argv[1]);
+    }
+
+    int *sensor = NULL;
+    if (argc > 2) {
+        int val = 42;
+        sensor = &val;
+    }
+    printf("sensor: %d\n", read_sensor(sensor));
+
+    char *pkt = build_packet(256);
+    if (pkt != NULL) {
+        printf("packet built\n");
+        free(pkt);
+    }
+
+    process_buffer();
+
+    void *matrix = allocate_matrix(1000, 1000000);
+    if (matrix != NULL) {
+        free(matrix);
+    }
+
+    int checksum = compute_checksum(argc);
+    printf("checksum: %d\n", checksum);
+
+    return 0;
+}


### PR DESCRIPTION
Closes #4

## What Changed

### SARIF Ingestion
- **Implemented `parse_sarif(sarif_path) → list[Vulnerability]`** in `parsers/sarif_parser.py`
  - Extracts: `ruleId`, `message`, file path, `startLine`, `startColumn`
  - Extracts function name from `logicalLocations` when present (prefers `kind: function/method`)
  - Each result parsed in isolation — malformed entries emit a `logging.warning` and are skipped without aborting the run
  - Handles missing `physicalLocation`, null regions, and missing `ruleId` gracefully

### Rule/CWE Mapping
- **Created `parsers/sarif_rule_map.py`** as standalone configuration (not embedded in parser logic)
  - `resolve_category(rule_id)` — exact match → prefix fallback → `UNKNOWN`
  - `resolve_cwe(rule_id, category)` — exact match → category fallback CWE
  - Covers ~35 Clang Static Analyzer rule IDs across: buffer overflow, null deref, leak, use-after-free, integer overflow, format string, divide-by-zero, uninitialized, deadlock
- **CWE resolution priority (per result):** SARIF result property tags → in-SARIF rule definition (tags or taxonomy relationships) → `sarif_rule_map` lookup → category fallback

### Model
- **Added `VulnerabilityCategory` enum** to enums.py with 10 values matching the coarse categories above
- `Vulnerability.category` is now typed against `VulnerabilityCategory.value` strings