### PR TITLE
Implements deterministic expert system risk scorer

### DIFF
--- a/constraintguard/scoring/__init__.py
+++ b/constraintguard/scoring/__init__.py
@@ -1,0 +1,8 @@
+from constraintguard.scoring.engine import score_all, score_vulnerability
+from constraintguard.scoring.rules import RULE_REGISTRY
+
+__all__ = [
+    "score_vulnerability",
+    "score_all",
+    "RULE_REGISTRY",
+]

--- a/constraintguard/scoring/base_scores.py
+++ b/constraintguard/scoring/base_scores.py
@@ -1,0 +1,20 @@
+from constraintguard.models.enums import VulnerabilityCategory
+
+CATEGORY_BASE_SCORES: dict[str, int] = {
+    VulnerabilityCategory.USE_AFTER_FREE.value: 65,
+    VulnerabilityCategory.BUFFER_OVERFLOW.value: 60,
+    VulnerabilityCategory.FORMAT_STRING.value: 55,
+    VulnerabilityCategory.NULL_DEREF.value: 50,
+    VulnerabilityCategory.INTEGER_OVERFLOW.value: 50,
+    VulnerabilityCategory.LEAK.value: 45,
+    VulnerabilityCategory.DEADLOCK.value: 45,
+    VulnerabilityCategory.DIVIDE_BY_ZERO.value: 40,
+    VulnerabilityCategory.UNINITIALIZED.value: 40,
+    VulnerabilityCategory.UNKNOWN.value: 35,
+}
+
+DEFAULT_BASE_SCORE = 35
+
+
+def base_score_for_category(category: str) -> int:
+    return CATEGORY_BASE_SCORES.get(category, DEFAULT_BASE_SCORE)

--- a/constraintguard/scoring/engine.py
+++ b/constraintguard/scoring/engine.py
@@ -1,0 +1,124 @@
+from constraintguard.models.enums import score_to_tier
+from constraintguard.models.hardware_spec import HardwareSpec
+from constraintguard.models.risk_report import RiskItem, RuleFiring
+from constraintguard.models.vulnerability import Vulnerability
+from constraintguard.scoring.base_scores import base_score_for_category
+from constraintguard.scoring.rules import RULE_REGISTRY
+
+_SCORE_MIN = 0
+_SCORE_MAX = 100
+
+_REMEDIATION_TEMPLATES: dict[str, str] = {
+    "buffer_overflow": (
+        "Replace unsafe string/memory operations with size-bounded equivalents "
+        "(e.g., strncpy, snprintf, memcpy with explicit length checks). "
+        "Validate all input lengths before copying into fixed-size buffers."
+    ),
+    "null_deref": (
+        "Add null-pointer guards before every pointer dereference. "
+        "Use assertion macros in debug builds and explicit error-return paths in production."
+    ),
+    "leak": (
+        "Ensure every allocation has a corresponding free on all exit paths. "
+        "Consider RAII patterns (C++) or ownership-tracking macros (C) to make lifetime explicit."
+    ),
+    "use_after_free": (
+        "Set pointers to NULL immediately after freeing. "
+        "Audit all pointer copies and lifetime boundaries; prefer single-owner allocation patterns."
+    ),
+    "integer_overflow": (
+        "Validate arithmetic operands against their type bounds before computation. "
+        "Use compiler sanitizers (UBSan) during testing and consider safe-integer wrappers."
+    ),
+    "format_string": (
+        "Replace user-controlled format strings with a fixed format literal. "
+        "Always pass a format string explicitly: printf(\"%s\", user_input)."
+    ),
+    "divide_by_zero": (
+        "Guard all divisors with an explicit non-zero check before division. "
+        "Return an error or safe default value when the divisor is zero."
+    ),
+    "uninitialized": (
+        "Initialize all variables at declaration. "
+        "Enable -Wuninitialized/-Wmaybe-uninitialized compiler warnings and treat them as errors."
+    ),
+    "deadlock": (
+        "Enforce a consistent global lock-acquisition ordering across all execution paths. "
+        "Avoid holding locks while calling functions that may acquire additional locks."
+    ),
+    "unknown": (
+        "Review the finding manually and apply the principle of least privilege. "
+        "Consult the tool documentation for the specific rule that triggered this finding."
+    ),
+}
+
+_DEFAULT_REMEDIATION = _REMEDIATION_TEMPLATES["unknown"]
+
+
+def _apply_rules(vuln: Vulnerability, spec: HardwareSpec) -> list[RuleFiring]:
+    firings: list[RuleFiring] = []
+    for rule_fn in RULE_REGISTRY:
+        firing = rule_fn(vuln, spec)
+        if firing is not None:
+            firings.append(firing)
+    return firings
+
+
+def _clip_score(score: int) -> int:
+    return max(_SCORE_MIN, min(_SCORE_MAX, score))
+
+
+def _build_explanation(
+    vuln: Vulnerability,
+    base_score: int,
+    final_score: int,
+    firings: list[RuleFiring],
+) -> str:
+    if not firings:
+        return (
+            f"Base {vuln.category} finding (base score {base_score}). "
+            "No constraint-specific escalations applied."
+        )
+
+    rule_rationales = " ".join(f"{f.rationale}" for f in firings)
+    return (
+        f"Base {vuln.category} finding (base score {base_score}). "
+        f"Constraint escalations applied: {rule_rationales} "
+        f"Final score: {final_score}."
+    )
+
+
+def _build_remediation(category: str) -> str:
+    return _REMEDIATION_TEMPLATES.get(category, _DEFAULT_REMEDIATION)
+
+
+def score_vulnerability(vuln: Vulnerability, spec: HardwareSpec) -> RiskItem:
+    base_score = base_score_for_category(vuln.category)
+    firings = _apply_rules(vuln, spec)
+    raw_final = base_score + sum(f.delta for f in firings)
+    final_score = _clip_score(raw_final)
+    tier = score_to_tier(final_score)
+    explanation = _build_explanation(vuln, base_score, final_score, firings)
+    remediation = _build_remediation(vuln.category)
+
+    return RiskItem(
+        vulnerability=vuln,
+        base_score=base_score,
+        final_score=final_score,
+        tier=tier,
+        rule_firings=firings,
+        explanation=explanation,
+        remediation=remediation,
+    )
+
+
+def score_all(vulns: list[Vulnerability], spec: HardwareSpec) -> list[RiskItem]:
+    items = [score_vulnerability(vuln, spec) for vuln in vulns]
+    return sorted(
+        items,
+        key=lambda item: (
+            -item.final_score,
+            item.vulnerability.path,
+            item.vulnerability.start_line or 0,
+        ),
+    )

--- a/constraintguard/scoring/rules.py
+++ b/constraintguard/scoring/rules.py
@@ -1,0 +1,284 @@
+import re
+from typing import Callable
+
+from constraintguard.models.hardware_spec import HardwareSpec
+from constraintguard.models.risk_report import RuleFiring
+from constraintguard.models.vulnerability import Vulnerability
+
+RuleFunction = Callable[[Vulnerability, HardwareSpec], RuleFiring | None]
+
+_MEMORY_SAFETY_CATEGORIES = {"buffer_overflow", "use_after_free", "null_deref"}
+_OVERFLOW_UAF_CATEGORIES = {"buffer_overflow", "use_after_free"}
+_LEAK_UAF_CATEGORIES = {"leak", "use_after_free"}
+_HIGH_IMPACT_CATEGORIES = {"buffer_overflow", "use_after_free", "null_deref", "format_string"}
+_ASIL_HIGH_LEVELS = {"asil-b", "asil-c", "asil-d"}
+_FUNCTIONAL_SAFETY_PREFIXES = ("iso26262", "iec62443", "do-178", "iec61508", "misra")
+
+_ISR_PREFIX_PATTERN = re.compile(r"^(isr_|ISR_)", re.ASCII)
+_ISR_SUFFIX_PATTERN = re.compile(r"(_isr|_ISR|_irq|_IRQ|_IRQHandler)$", re.ASCII)
+_ISR_CMSIS_PATTERN = re.compile(
+    r"(SysTick_Handler|PendSV_Handler|HardFault_Handler|NMI_Handler|MemManage_Handler"
+    r"|BusFault_Handler|UsageFault_Handler|DebugMon_Handler)",
+    re.ASCII,
+)
+
+
+def _is_isr_function(name: str | None) -> bool:
+    if not name:
+        return False
+    if _ISR_PREFIX_PATTERN.match(name):
+        return True
+    if _ISR_SUFFIX_PATTERN.search(name):
+        return True
+    if "interrupt" in name.lower():
+        return True
+    if _ISR_CMSIS_PATTERN.search(name):
+        return True
+    return False
+
+
+def _is_high_asil(safety_level: str | None) -> bool:
+    if not safety_level:
+        return False
+    normalized = safety_level.lower()
+    return any(asil in normalized for asil in _ASIL_HIGH_LEVELS)
+
+
+def _is_functional_safety(safety_level: str | None) -> bool:
+    if not safety_level:
+        return False
+    normalized = safety_level.lower()
+    return any(normalized.startswith(prefix) or prefix in normalized for prefix in _FUNCTIONAL_SAFETY_PREFIXES)
+
+
+def _rule_mem_stack_tight(vuln: Vulnerability, spec: HardwareSpec) -> RuleFiring | None:
+    if spec.stack_size_bytes is None:
+        return None
+    if spec.stack_size_bytes > 4096:
+        return None
+    if vuln.category not in _OVERFLOW_UAF_CATEGORIES:
+        return None
+    return RuleFiring(
+        rule_id="R-MEM-STACK-TIGHT",
+        delta=20,
+        rationale=(
+            f"Stack is tightly constrained at {spec.stack_size_bytes}B (≤4096B); "
+            f"{vuln.category} can overwrite stack frames and corrupt return addresses."
+        ),
+        constraints_used=["stack_size_bytes"],
+    )
+
+
+def _rule_mem_heap_tight(vuln: Vulnerability, spec: HardwareSpec) -> RuleFiring | None:
+    if spec.heap_size_bytes is None:
+        return None
+    if spec.heap_size_bytes > 8192:
+        return None
+    if vuln.category != "leak":
+        return None
+    return RuleFiring(
+        rule_id="R-MEM-HEAP-TIGHT",
+        delta=15,
+        rationale=(
+            f"Heap budget is only {spec.heap_size_bytes}B (≤8192B); "
+            "repeated memory leaks rapidly exhaust the allocation pool and trigger undefined behaviour."
+        ),
+        constraints_used=["heap_size_bytes"],
+    )
+
+
+def _rule_mem_ram_tight(vuln: Vulnerability, spec: HardwareSpec) -> RuleFiring | None:
+    if spec.ram_size_bytes is None:
+        return None
+    if spec.ram_size_bytes > 65536:
+        return None
+    if vuln.category not in _MEMORY_SAFETY_CATEGORIES:
+        return None
+    return RuleFiring(
+        rule_id="R-MEM-RAM-TIGHT",
+        delta=15,
+        rationale=(
+            f"Total RAM is limited to {spec.ram_size_bytes}B (≤64KB); "
+            f"{vuln.category} corrupts a significant fraction of addressable memory on this device."
+        ),
+        constraints_used=["ram_size_bytes"],
+    )
+
+
+def _rule_mem_no_dynamic(vuln: Vulnerability, spec: HardwareSpec) -> RuleFiring | None:
+    if spec.heap_size_bytes is not None:
+        return None
+    if vuln.category not in _LEAK_UAF_CATEGORIES:
+        return None
+    return RuleFiring(
+        rule_id="R-MEM-NO-DYNAMIC",
+        delta=10,
+        rationale=(
+            "No heap budget is declared in the constraint profile; "
+            f"a {vuln.category} defect suggests untracked or unexpected dynamic allocation on this target."
+        ),
+        constraints_used=["heap_size_bytes"],
+    )
+
+
+def _rule_isr_func_name(vuln: Vulnerability, spec: HardwareSpec) -> RuleFiring | None:
+    if not _is_isr_function(vuln.function):
+        return None
+    return RuleFiring(
+        rule_id="R-ISR-FUNC-NAME",
+        delta=25,
+        rationale=(
+            f"Function '{vuln.function}' matches interrupt service routine naming conventions; "
+            "a fault in an ISR cannot be caught by normal exception handling and may lock the device."
+        ),
+        constraints_used=["function"],
+    )
+
+
+def _rule_isr_latency_overflow(vuln: Vulnerability, spec: HardwareSpec) -> RuleFiring | None:
+    if spec.max_interrupt_latency_us is None:
+        return None
+    if spec.max_interrupt_latency_us > 100:
+        return None
+    if vuln.category not in _MEMORY_SAFETY_CATEGORIES:
+        return None
+    return RuleFiring(
+        rule_id="R-ISR-LATENCY-OVERFLOW",
+        delta=15,
+        rationale=(
+            f"Maximum interrupt latency budget is {spec.max_interrupt_latency_us}µs (≤100µs); "
+            f"a {vuln.category} in an interrupt-sensitive code path can cause a missed real-time deadline."
+        ),
+        constraints_used=["max_interrupt_latency_us"],
+    )
+
+
+def _rule_isr_deadlock(vuln: Vulnerability, spec: HardwareSpec) -> RuleFiring | None:
+    if vuln.category != "deadlock":
+        return None
+    if not _is_isr_function(vuln.function):
+        return None
+    function_label = vuln.function or "unknown ISR"
+    return RuleFiring(
+        rule_id="R-ISR-DEADLOCK",
+        delta=30,
+        rationale=(
+            f"Deadlock detected in interrupt service routine '{function_label}'; "
+            "interrupt starvation caused by a deadlock in an ISR requires a hardware reset to recover."
+        ),
+        constraints_used=["function"],
+    )
+
+
+def _rule_crit_func(vuln: Vulnerability, spec: HardwareSpec) -> RuleFiring | None:
+    if not spec.critical_functions:
+        return None
+    if not vuln.function:
+        return None
+    if vuln.function not in spec.critical_functions:
+        return None
+    return RuleFiring(
+        rule_id="R-CRIT-FUNC",
+        delta=25,
+        rationale=(
+            f"Function '{vuln.function}' is designated safety-critical in the constraint profile; "
+            "any defect in this function directly impacts controlled system operation."
+        ),
+        constraints_used=["critical_functions"],
+    )
+
+
+def _rule_safety_asil_strict(vuln: Vulnerability, spec: HardwareSpec) -> RuleFiring | None:
+    if not _is_high_asil(spec.safety_level):
+        return None
+    if vuln.category not in _HIGH_IMPACT_CATEGORIES:
+        return None
+    return RuleFiring(
+        rule_id="R-SAFETY-ASIL-STRICT",
+        delta=15,
+        rationale=(
+            f"Safety integrity level '{spec.safety_level}' mandates deterministic memory-safe behaviour; "
+            f"{vuln.category} directly violates ISO 26262 ASIL freedom-from-interference requirements."
+        ),
+        constraints_used=["safety_level"],
+    )
+
+
+def _rule_safety_functional(vuln: Vulnerability, spec: HardwareSpec) -> RuleFiring | None:
+    if not _is_functional_safety(spec.safety_level):
+        return None
+    return RuleFiring(
+        rule_id="R-SAFETY-FUNCTIONAL",
+        delta=5,
+        rationale=(
+            f"Functional safety standard '{spec.safety_level}' is declared for this target; "
+            "all findings are escalated to reflect stricter acceptance criteria."
+        ),
+        constraints_used=["safety_level"],
+    )
+
+
+def _rule_time_ultra_tight(vuln: Vulnerability, spec: HardwareSpec) -> RuleFiring | None:
+    if spec.max_interrupt_latency_us is None:
+        return None
+    if spec.max_interrupt_latency_us > 50:
+        return None
+    return RuleFiring(
+        rule_id="R-TIME-ULTRA-TIGHT",
+        delta=10,
+        rationale=(
+            f"Interrupt latency budget is extremely tight at {spec.max_interrupt_latency_us}µs (≤50µs); "
+            "findings across any execution path are escalated due to near-zero timing slack."
+        ),
+        constraints_used=["max_interrupt_latency_us"],
+    )
+
+
+def _rule_latency_deadlock(vuln: Vulnerability, spec: HardwareSpec) -> RuleFiring | None:
+    if spec.max_interrupt_latency_us is None:
+        return None
+    if vuln.category != "deadlock":
+        return None
+    return RuleFiring(
+        rule_id="R-LATENCY-DEADLOCK",
+        delta=20,
+        rationale=(
+            f"Interrupt latency budget of {spec.max_interrupt_latency_us}µs is declared; "
+            "a deadlock anywhere in the system can prevent interrupt servicing and violate this budget."
+        ),
+        constraints_used=["max_interrupt_latency_us"],
+    )
+
+
+def _rule_safety_int_overflow(vuln: Vulnerability, spec: HardwareSpec) -> RuleFiring | None:
+    if not _is_functional_safety(spec.safety_level):
+        return None
+    if vuln.category != "integer_overflow":
+        return None
+    return RuleFiring(
+        rule_id="R-SAFETY-INT-OVF",
+        delta=12,
+        rationale=(
+            f"Safety standard '{spec.safety_level}' is active; "
+            "integer overflow can silently produce incorrect sensor or actuator values, "
+            "violating numerical safety invariants."
+        ),
+        constraints_used=["safety_level"],
+    )
+
+
+RULE_REGISTRY: list[RuleFunction] = [
+    _rule_mem_stack_tight,
+    _rule_mem_heap_tight,
+    _rule_mem_ram_tight,
+    _rule_mem_no_dynamic,
+    _rule_isr_func_name,
+    _rule_isr_latency_overflow,
+    _rule_isr_deadlock,
+    _rule_crit_func,
+    _rule_safety_asil_strict,
+    _rule_safety_functional,
+    _rule_time_ultra_tight,
+    _rule_latency_deadlock,
+    _rule_safety_int_overflow,
+]


### PR DESCRIPTION
Closes task #5 #6

## What Changed

### Rule Registry (`scoring/rules.py`)
- **Implemented 13 deterministic scoring rules** across 4 families, each as a pure function `(Vulnerability, HardwareSpec) → RuleFiring | None`
  - **Memory tightness:** stack ≤ 4096B + overflow/UAF (+20), heap ≤ 8192B + leak (+15), RAM ≤ 64KB + memory-safety (+15), no heap declared + leak/UAF (+10)
  - **ISR context:** function name matches ISR patterns (+25), latency ≤ 100µs + memory-safety (+15), deadlock in ISR function (+30)
  - **Safety criticality:** function in `critical_functions` list (+25), ASIL-B/C/D + high-impact category (+15), any functional safety standard present (+5), functional safety + integer overflow (+12)
  - **Timing:** latency ≤ 50µs global escalation (+10), latency budget + deadlock (+20)
- `RULE_REGISTRY` is a fixed-order list — iteration order is stable across runs

### Scoring Engine (`scoring/engine.py`)
- **`score_vulnerability(vuln, spec) -> RiskItem`** — base score + additive rule deltas, clipped to [0–100], assigns `SeverityTier`, produces deterministic explanation and remediation template
- **`score_all(vulns, spec) -> list[RiskItem]`** — scores all findings and sorts by `(-final_score, path, line)` for stable ordering
- Remediation templates cover all 9 `VulnerabilityCategory` values

### Base Scores (`scoring/base_scores.py`)
- Maps each `VulnerabilityCategory` to a deterministic base score (35–65), with `use_after_free` and `buffer_overflow` ranked highest by default

### Public API (__init__.py)
- Exports `score_vulnerability`, `score_all`, `RULE_REGISTRY`