### PR TITLE
Explanation + remediation templates for deterministic constraint-referenced reporting

### DIFF
--- a/constraintguard/reporting/__init__.py
+++ b/constraintguard/reporting/__init__.py
@@ -1,0 +1,15 @@
+from constraintguard.reporting.console import print_report_to_console
+from constraintguard.reporting.constraints_summary import (
+    build_constraints_summary_lines,
+    build_constraints_summary_text,
+)
+from constraintguard.reporting.explanation import build_explanation
+from constraintguard.reporting.remediation import build_remediation
+
+__all__ = [
+    "build_constraints_summary_lines",
+    "build_constraints_summary_text",
+    "build_explanation",
+    "build_remediation",
+    "print_report_to_console",
+]

--- a/constraintguard/reporting/console.py
+++ b/constraintguard/reporting/console.py
@@ -1,0 +1,143 @@
+import textwrap
+
+from constraintguard.models.enums import SeverityTier
+from constraintguard.models.risk_report import RiskItem, RiskReport
+from constraintguard.reporting.constraints_summary import build_constraints_summary_lines
+
+_SECTION_WIDTH = 72
+_SECTION_LINE = "═" * _SECTION_WIDTH
+_RULE_LINE = "─" * _SECTION_WIDTH
+_INDENT = "  "
+_BODY_INDENT = "    "
+_WRAP_WIDTH = 68
+
+_TIER_LABEL_WIDTH = 10
+
+_TIER_DISPLAY: dict[SeverityTier, str] = {
+    SeverityTier.CRITICAL: "CRITICAL",
+    SeverityTier.HIGH: "HIGH",
+    SeverityTier.MEDIUM: "MEDIUM",
+    SeverityTier.LOW: "LOW",
+}
+
+
+def _tier_bar(count: int, max_count: int, bar_width: int = 20) -> str:
+    if max_count == 0 or count == 0:
+        return "░" * bar_width
+    filled = max(1, round((count / max_count) * bar_width))
+    return "█" * filled + "░" * (bar_width - filled)
+
+
+def _fired_rules_line(item: RiskItem) -> str:
+    if not item.rule_firings:
+        return "none"
+    parts = [f"{f.rule_id}({f.delta:+d})" for f in item.rule_firings]
+    return ", ".join(parts)
+
+
+def _print_section_header(title: str) -> None:
+    print(_SECTION_LINE)
+    print(f"{_INDENT}{title}")
+    print(_SECTION_LINE)
+
+
+def _print_rule_header(title: str) -> None:
+    print(_RULE_LINE)
+    print(f"{_INDENT}{title}")
+    print(_RULE_LINE)
+
+
+def _print_constraints_block(report: RiskReport) -> None:
+    _print_rule_header("Constraint Profile")
+    for line in build_constraints_summary_lines(report.hardware_spec, report.provenance):
+        print(f"{_INDENT}{line}")
+    print()
+
+
+def _print_severity_distribution(report: RiskReport) -> None:
+    counts = report.summary.tier_counts
+    tier_values: dict[SeverityTier, int] = {
+        SeverityTier.CRITICAL: counts.critical,
+        SeverityTier.HIGH: counts.high,
+        SeverityTier.MEDIUM: counts.medium,
+        SeverityTier.LOW: counts.low,
+    }
+    max_count = max(tier_values.values(), default=1) or 1
+    _print_rule_header("Severity Distribution")
+    for tier, count in tier_values.items():
+        label = _TIER_DISPLAY[tier].ljust(_TIER_LABEL_WIDTH)
+        bar = _tier_bar(count, max_count)
+        print(f"{_INDENT}{label}  {bar}  {count}")
+    print(f"{_INDENT}{'Total:'.ljust(_TIER_LABEL_WIDTH)}  {' ' * 20}  {report.summary.total_findings}")
+    print()
+
+
+def _print_finding(rank: int, item: RiskItem) -> None:
+    tier_label = _TIER_DISPLAY[item.tier]
+    location = item.vulnerability.path
+    if item.vulnerability.start_line:
+        location = f"{location}:{item.vulnerability.start_line}"
+
+    fn_part = f"  in {item.vulnerability.function}" if item.vulnerability.function else ""
+    rule_part = f"  [{item.vulnerability.rule_id}]" if item.vulnerability.rule_id else ""
+
+    print(f"{_INDENT}[{rank}] {tier_label}  score: {item.final_score}  category: {item.vulnerability.category}")
+    print(f"{_BODY_INDENT}{location}{fn_part}{rule_part}")
+    print()
+
+    for line in textwrap.wrap(
+        item.explanation,
+        width=_WRAP_WIDTH,
+        initial_indent=_BODY_INDENT,
+        subsequent_indent=_BODY_INDENT,
+    ):
+        print(line)
+    print()
+
+    print(f"{_BODY_INDENT}Remediation:")
+    for line in textwrap.wrap(
+        item.remediation,
+        width=_WRAP_WIDTH,
+        initial_indent=_BODY_INDENT + "  ",
+        subsequent_indent=_BODY_INDENT + "  ",
+    ):
+        print(line)
+    print()
+
+    print(f"{_BODY_INDENT}Fired rules: {_fired_rules_line(item)}")
+    print()
+    print(f"{_INDENT}{_RULE_LINE}")
+
+
+def print_report_to_console(report: RiskReport, top_k: int = 10) -> None:
+    platform = report.hardware_spec.platform or "embedded target"
+    safety = (
+        f" ({report.hardware_spec.safety_level})"
+        if report.hardware_spec.safety_level
+        else ""
+    )
+    timestamp = report.run_metadata.timestamp.strftime("%Y-%m-%d %H:%M:%S UTC")
+
+    print()
+    _print_section_header(f"ConstraintGuard Risk Report — {platform}{safety}")
+    print(f"{_INDENT}Run: {timestamp}")
+    if report.run_metadata.source_path:
+        print(f"{_INDENT}Source: {report.run_metadata.source_path}")
+    if report.run_metadata.config_path:
+        print(f"{_INDENT}Config: {report.run_metadata.config_path}")
+    print()
+
+    _print_constraints_block(report)
+    _print_severity_distribution(report)
+
+    top_items = report.items[:top_k]
+    if not top_items:
+        print(f"{_INDENT}No findings to display.")
+        return
+
+    _print_rule_header(f"Top {len(top_items)} Finding(s)")
+    print()
+    for rank, item in enumerate(top_items, start=1):
+        _print_finding(rank, item)
+
+    print()

--- a/constraintguard/reporting/constraints_summary.py
+++ b/constraintguard/reporting/constraints_summary.py
@@ -1,0 +1,53 @@
+from constraintguard.models.hardware_spec import ConstraintProvenance, HardwareSpec
+from constraintguard.reporting.formatting import format_bytes, format_us
+
+
+def build_constraints_summary_lines(
+    spec: HardwareSpec,
+    provenance: ConstraintProvenance | None = None,
+) -> list[str]:
+    lines: list[str] = []
+
+    header_parts: list[str] = []
+    if spec.platform:
+        header_parts.append(spec.platform)
+    if spec.safety_level:
+        header_parts.append(spec.safety_level)
+    label = " — ".join(header_parts) if header_parts else "(no profile specified)"
+    lines.append(f"Constraint Profile: {label}")
+
+    mem_fields: list[tuple[str, str]] = []
+    if spec.ram_size_bytes is not None:
+        mem_fields.append(("RAM", format_bytes(spec.ram_size_bytes)))
+    if spec.flash_size_bytes is not None:
+        mem_fields.append(("Flash", format_bytes(spec.flash_size_bytes)))
+    if spec.stack_size_bytes is not None:
+        mem_fields.append(("Stack", format_bytes(spec.stack_size_bytes)))
+    if spec.heap_size_bytes is not None:
+        mem_fields.append(("Heap", format_bytes(spec.heap_size_bytes)))
+    if mem_fields:
+        lines.append("  " + "   ".join(f"{k}: {v}" for k, v in mem_fields))
+
+    if spec.max_interrupt_latency_us is not None:
+        lines.append(f"  Max IRQ Latency: {format_us(spec.max_interrupt_latency_us)}")
+
+    if spec.critical_functions:
+        lines.append(f"  Critical Functions: {', '.join(spec.critical_functions)}")
+
+    if provenance and provenance.field_origins:
+        sources = sorted({
+            fp.source_path
+            for fp in provenance.field_origins.values()
+            if fp.source_path
+        })
+        if sources:
+            lines.append(f"  Sources: {', '.join(sources)}")
+
+    return lines
+
+
+def build_constraints_summary_text(
+    spec: HardwareSpec,
+    provenance: ConstraintProvenance | None = None,
+) -> str:
+    return "\n".join(build_constraints_summary_lines(spec, provenance))

--- a/constraintguard/reporting/explanation.py
+++ b/constraintguard/reporting/explanation.py
@@ -1,0 +1,139 @@
+from constraintguard.models.hardware_spec import HardwareSpec
+from constraintguard.models.risk_report import RuleFiring
+from constraintguard.models.vulnerability import Vulnerability
+from constraintguard.reporting.formatting import format_bytes, format_us
+
+_CATEGORY_PLAIN_NAMES: dict[str, str] = {
+    "buffer_overflow": "buffer overflow",
+    "null_deref": "null pointer dereference",
+    "leak": "memory leak",
+    "use_after_free": "use-after-free",
+    "integer_overflow": "integer overflow",
+    "format_string": "format string vulnerability",
+    "divide_by_zero": "division by zero",
+    "uninitialized": "uninitialized memory read",
+    "deadlock": "potential deadlock",
+    "unknown": "static analysis finding",
+}
+
+_CATEGORY_EMBEDDED_CONSEQUENCE: dict[str, str] = {
+    "buffer_overflow": (
+        "corrupts adjacent memory, potentially overwriting stack frames, return addresses, "
+        "or global state — on a resource-constrained embedded target, recovery may require a full device reset"
+    ),
+    "null_deref": (
+        "triggers a processor fault (e.g., ARM HardFault) that halts execution immediately "
+        "— on bare-metal or RTOS targets there is typically no OS-level exception handler to recover from this"
+    ),
+    "leak": (
+        "permanently consumes heap or pool memory on each call path that reaches it "
+        "— on embedded targets with kilobytes of RAM, repeated leaks exhaust available memory rapidly"
+    ),
+    "use_after_free": (
+        "accesses freed memory that may have been reallocated, introducing non-deterministic behaviour "
+        "— on embedded targets without full memory protection, this can silently corrupt live data structures"
+    ),
+    "integer_overflow": (
+        "silently wraps arithmetic results, producing incorrect values that propagate through "
+        "control, sensor, or actuator calculations without any runtime indication"
+    ),
+    "format_string": (
+        "allows arbitrary memory reads and writes via format specifiers if user input reaches the format argument "
+        "— on embedded targets, this can compromise the entire firmware image"
+    ),
+    "divide_by_zero": (
+        "triggers a processor divide-by-zero fault that halts execution "
+        "unless an explicit trap handler is installed and tested"
+    ),
+    "uninitialized": (
+        "reads indeterminate stack or register values, producing device-specific non-deterministic behaviour "
+        "that is difficult to reproduce and may differ between debug and release builds"
+    ),
+    "deadlock": (
+        "permanently blocks one or more tasks from running "
+        "— on an RTOS or bare-metal scheduler, this starves all dependent tasks and interrupts indefinitely"
+    ),
+    "unknown": (
+        "produces undefined behaviour whose exact impact depends on the execution context and runtime state"
+    ),
+}
+
+
+def _location_phrase(vuln: Vulnerability) -> str:
+    if vuln.function and vuln.start_line:
+        return f"in function '{vuln.function}' ({vuln.path}:{vuln.start_line})"
+    if vuln.function:
+        return f"in function '{vuln.function}' ({vuln.path})"
+    if vuln.start_line:
+        return f"at {vuln.path}:{vuln.start_line}"
+    return f"in {vuln.path}"
+
+
+def _profile_descriptor(spec: HardwareSpec) -> str:
+    parts: list[str] = []
+    if spec.platform:
+        parts.append(spec.platform)
+    if spec.safety_level:
+        parts.append(spec.safety_level)
+    if parts:
+        return f"your {' / '.join(parts)} target"
+    return "this embedded target"
+
+
+def _build_no_constraint_context_sentence(spec: HardwareSpec) -> str:
+    mem_parts: list[str] = []
+    if spec.ram_size_bytes is not None:
+        mem_parts.append(f"{format_bytes(spec.ram_size_bytes)} RAM")
+    if spec.stack_size_bytes is not None:
+        mem_parts.append(f"{format_bytes(spec.stack_size_bytes)} stack")
+    if spec.heap_size_bytes is not None:
+        mem_parts.append(f"{format_bytes(spec.heap_size_bytes)} heap")
+    if spec.max_interrupt_latency_us is not None:
+        mem_parts.append(f"{format_us(spec.max_interrupt_latency_us)} interrupt latency budget")
+    if mem_parts:
+        profile = _profile_descriptor(spec)
+        return f"The constraint profile for {profile} declares {', '.join(mem_parts)}."
+    return ""
+
+
+def _combine_rationales(firings: list[RuleFiring]) -> str:
+    rationales = [f.rationale.rstrip(".") for f in firings]
+    if len(rationales) == 1:
+        return rationales[0] + "."
+    if len(rationales) == 2:
+        return f"{rationales[0]}; and {rationales[1]}."
+    body = "; ".join(rationales[:-1])
+    return f"{body}; and {rationales[-1]}."
+
+
+def build_explanation(
+    vuln: Vulnerability,
+    spec: HardwareSpec,
+    base_score: int,
+    final_score: int,
+    firings: list[RuleFiring],
+) -> str:
+    plain_name = _CATEGORY_PLAIN_NAMES.get(vuln.category, vuln.category)
+    location = _location_phrase(vuln)
+    profile = _profile_descriptor(spec)
+    consequence = _CATEGORY_EMBEDDED_CONSEQUENCE.get(
+        vuln.category, _CATEGORY_EMBEDDED_CONSEQUENCE["unknown"]
+    )
+
+    opening = f"A {plain_name} was detected {location}."
+
+    if not firings:
+        ctx = _build_no_constraint_context_sentence(spec)
+        ctx_part = f" {ctx}" if ctx else ""
+        return (
+            f"{opening}{ctx_part} "
+            f"On {profile}, this {consequence}. "
+            f"No constraint-specific escalations apply to this finding (base score: {base_score})."
+        )
+
+    rationale_sentence = _combine_rationales(firings)
+    return (
+        f"{opening} "
+        f"On {profile}, this {consequence}. "
+        f"This finding is escalated because: {rationale_sentence}"
+    )

--- a/constraintguard/reporting/formatting.py
+++ b/constraintguard/reporting/formatting.py
@@ -1,0 +1,14 @@
+def format_bytes(n: int) -> str:
+    if n >= 1_048_576:
+        return f"{n // 1_048_576}MB"
+    if n >= 1024:
+        return f"{n // 1024}KB"
+    return f"{n}B"
+
+
+def format_us(n: int) -> str:
+    if n >= 1_000_000:
+        return f"{n // 1_000_000}s"
+    if n >= 1000:
+        return f"{n // 1000}ms"
+    return f"{n}µs"

--- a/constraintguard/reporting/remediation.py
+++ b/constraintguard/reporting/remediation.py
@@ -1,0 +1,129 @@
+from constraintguard.models.hardware_spec import HardwareSpec
+from constraintguard.reporting.formatting import format_bytes, format_us
+
+_BASE_REMEDIATION_TEMPLATES: dict[str, str] = {
+    "buffer_overflow": (
+        "Replace unsafe memory operations with size-bounded equivalents "
+        "(strncpy, snprintf, memcpy with explicit length). "
+        "Validate all input lengths before copying into fixed-size buffers. "
+        "On embedded targets, prefer statically-sized buffers with compile-time size assertions "
+        "that enforce upper bounds."
+    ),
+    "null_deref": (
+        "Add null-pointer guards before every pointer dereference. "
+        "Use assertion macros in debug builds and explicit error-return paths in production. "
+        "On bare-metal targets, a null dereference typically triggers a HardFault — "
+        "ensure a fault handler is installed that logs diagnostics and performs a controlled reset."
+    ),
+    "leak": (
+        "Ensure every allocation has a corresponding free on all exit paths, including error paths. "
+        "On embedded targets, consider replacing dynamic allocation with a static memory pool "
+        "or arena allocator, which eliminates fragmentation and removes leak risk entirely. "
+        "MISRA C Rule 21.3 prohibits dynamic memory allocation in safety-critical code."
+    ),
+    "use_after_free": (
+        "Set pointers to NULL immediately after freeing. "
+        "Audit all pointer copies and lifetime boundaries; prefer single-owner allocation patterns. "
+        "On embedded firmware, apply MPU read-after-free detection during testing "
+        "if the hardware supports memory protection."
+    ),
+    "integer_overflow": (
+        "Validate arithmetic operands against their type bounds before computation. "
+        "Enable UBSan (undefined behaviour sanitizer) during testing. "
+        "In safety-critical paths, use checked-arithmetic macros or a safe-integer library "
+        "that returns an error on overflow instead of wrapping silently."
+    ),
+    "format_string": (
+        "Replace any user-controlled format string argument with a fixed literal: "
+        "use printf(\"%s\", user_input) rather than printf(user_input). "
+        "On embedded targets, restrict or disable formatted I/O in production builds "
+        "to reduce both attack surface and code size."
+    ),
+    "divide_by_zero": (
+        "Guard all divisors with an explicit non-zero check before division. "
+        "Return a safe default or error code when the divisor is zero. "
+        "On embedded targets, install a divide-by-zero trap handler "
+        "that logs a diagnostic and performs a controlled reset rather than leaving the system in an unknown state."
+    ),
+    "uninitialized": (
+        "Initialize all variables at the point of declaration. "
+        "Enable -Wuninitialized and -Wmaybe-uninitialized compiler warnings and treat them as errors. "
+        "In safety-critical code, zero-initialize all buffers and structs explicitly "
+        "and avoid relying on BSS initialization order across translation units."
+    ),
+    "deadlock": (
+        "Enforce a consistent global lock-acquisition ordering across all execution paths. "
+        "Avoid holding locks while calling functions that may acquire additional locks. "
+        "On RTOS-based targets, use priority-ceiling or priority-inheritance mutexes "
+        "to prevent priority inversion alongside deadlock risks."
+    ),
+    "unknown": (
+        "Review the finding manually and apply the principle of least privilege. "
+        "Consult the static analyzer's rule documentation for guidance specific to this rule. "
+        "On embedded targets, treat any undefined behaviour conservatively — "
+        "assume it can corrupt device state and require a hardware reset to recover."
+    ),
+}
+
+_DEFAULT_REMEDIATION = _BASE_REMEDIATION_TEMPLATES["unknown"]
+
+
+def _constraint_addendum(category: str, spec: HardwareSpec) -> str | None:
+    if (
+        category in ("buffer_overflow", "use_after_free")
+        and spec.stack_size_bytes is not None
+        and spec.stack_size_bytes <= 4096
+    ):
+        return (
+            f"With only {format_bytes(spec.stack_size_bytes)} of stack on this target, "
+            "overflows are more likely to silently corrupt adjacent frames; "
+            "enable stack canaries (-fstack-protector-all) and MPU stack-guard regions if the hardware supports it."
+        )
+
+    if (
+        category == "leak"
+        and spec.heap_size_bytes is not None
+        and spec.heap_size_bytes <= 8192
+    ):
+        return (
+            f"With only {format_bytes(spec.heap_size_bytes)} of heap on this target, "
+            "a single recurring leak path will exhaust memory quickly; "
+            "replacing all dynamic allocation with a fixed-size pool allocator is strongly recommended."
+        )
+
+    if category == "null_deref" and spec.critical_functions:
+        return (
+            "In safety-critical functions, add both a pre-condition null check and a static assertion "
+            "to document and enforce the non-null invariant at compile time."
+        )
+
+    if category == "integer_overflow" and spec.safety_level:
+        return (
+            f"Under {spec.safety_level}, apply a MISRA-compliant checked-arithmetic pattern "
+            "for every arithmetic operation in the call path of this finding."
+        )
+
+    if category == "deadlock" and spec.max_interrupt_latency_us is not None:
+        return (
+            f"With a {format_us(spec.max_interrupt_latency_us)} interrupt latency budget, "
+            "any deadlock that blocks interrupt servicing will immediately violate this budget; "
+            "audit all lock acquisitions in interrupt-shared code paths."
+        )
+
+    if category == "uninitialized" and spec.safety_level:
+        return (
+            f"Under {spec.safety_level}, treat uninitialized reads as non-compliant by default and "
+            "require zero-initialization of all local variables in safety-relevant translation units."
+        )
+
+    return None
+
+
+def build_remediation(category: str, spec: HardwareSpec | None = None) -> str:
+    base = _BASE_REMEDIATION_TEMPLATES.get(category, _DEFAULT_REMEDIATION)
+    if spec is None:
+        return base
+    addendum = _constraint_addendum(category, spec)
+    if addendum is None:
+        return base
+    return f"{base} {addendum}"

--- a/constraintguard/scoring/engine.py
+++ b/constraintguard/scoring/engine.py
@@ -2,57 +2,13 @@ from constraintguard.models.enums import score_to_tier
 from constraintguard.models.hardware_spec import HardwareSpec
 from constraintguard.models.risk_report import RiskItem, RuleFiring
 from constraintguard.models.vulnerability import Vulnerability
+from constraintguard.reporting.explanation import build_explanation
+from constraintguard.reporting.remediation import build_remediation
 from constraintguard.scoring.base_scores import base_score_for_category
 from constraintguard.scoring.rules import RULE_REGISTRY
 
 _SCORE_MIN = 0
 _SCORE_MAX = 100
-
-_REMEDIATION_TEMPLATES: dict[str, str] = {
-    "buffer_overflow": (
-        "Replace unsafe string/memory operations with size-bounded equivalents "
-        "(e.g., strncpy, snprintf, memcpy with explicit length checks). "
-        "Validate all input lengths before copying into fixed-size buffers."
-    ),
-    "null_deref": (
-        "Add null-pointer guards before every pointer dereference. "
-        "Use assertion macros in debug builds and explicit error-return paths in production."
-    ),
-    "leak": (
-        "Ensure every allocation has a corresponding free on all exit paths. "
-        "Consider RAII patterns (C++) or ownership-tracking macros (C) to make lifetime explicit."
-    ),
-    "use_after_free": (
-        "Set pointers to NULL immediately after freeing. "
-        "Audit all pointer copies and lifetime boundaries; prefer single-owner allocation patterns."
-    ),
-    "integer_overflow": (
-        "Validate arithmetic operands against their type bounds before computation. "
-        "Use compiler sanitizers (UBSan) during testing and consider safe-integer wrappers."
-    ),
-    "format_string": (
-        "Replace user-controlled format strings with a fixed format literal. "
-        "Always pass a format string explicitly: printf(\"%s\", user_input)."
-    ),
-    "divide_by_zero": (
-        "Guard all divisors with an explicit non-zero check before division. "
-        "Return an error or safe default value when the divisor is zero."
-    ),
-    "uninitialized": (
-        "Initialize all variables at declaration. "
-        "Enable -Wuninitialized/-Wmaybe-uninitialized compiler warnings and treat them as errors."
-    ),
-    "deadlock": (
-        "Enforce a consistent global lock-acquisition ordering across all execution paths. "
-        "Avoid holding locks while calling functions that may acquire additional locks."
-    ),
-    "unknown": (
-        "Review the finding manually and apply the principle of least privilege. "
-        "Consult the tool documentation for the specific rule that triggered this finding."
-    ),
-}
-
-_DEFAULT_REMEDIATION = _REMEDIATION_TEMPLATES["unknown"]
 
 
 def _apply_rules(vuln: Vulnerability, spec: HardwareSpec) -> list[RuleFiring]:
@@ -68,38 +24,14 @@ def _clip_score(score: int) -> int:
     return max(_SCORE_MIN, min(_SCORE_MAX, score))
 
 
-def _build_explanation(
-    vuln: Vulnerability,
-    base_score: int,
-    final_score: int,
-    firings: list[RuleFiring],
-) -> str:
-    if not firings:
-        return (
-            f"Base {vuln.category} finding (base score {base_score}). "
-            "No constraint-specific escalations applied."
-        )
-
-    rule_rationales = " ".join(f"{f.rationale}" for f in firings)
-    return (
-        f"Base {vuln.category} finding (base score {base_score}). "
-        f"Constraint escalations applied: {rule_rationales} "
-        f"Final score: {final_score}."
-    )
-
-
-def _build_remediation(category: str) -> str:
-    return _REMEDIATION_TEMPLATES.get(category, _DEFAULT_REMEDIATION)
-
-
 def score_vulnerability(vuln: Vulnerability, spec: HardwareSpec) -> RiskItem:
     base_score = base_score_for_category(vuln.category)
     firings = _apply_rules(vuln, spec)
     raw_final = base_score + sum(f.delta for f in firings)
     final_score = _clip_score(raw_final)
     tier = score_to_tier(final_score)
-    explanation = _build_explanation(vuln, base_score, final_score, firings)
-    remediation = _build_remediation(vuln.category)
+    explanation = build_explanation(vuln, spec, base_score, final_score, firings)
+    remediation = build_remediation(vuln.category, spec)
 
     return RiskItem(
         vulnerability=vuln,

--- a/examples/mock_pipeline.py
+++ b/examples/mock_pipeline.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 from pathlib import Path
 
+from constraintguard.reporting import print_report_to_console
 from constraintguard.models import (
     ConstraintProvenance,
     ConstraintSourceType,
@@ -263,6 +264,7 @@ def generate_mock_report() -> RiskReport:
 
 if __name__ == "__main__":
     report = generate_mock_report()
+    print_report_to_console(report)
     output_path = Path(__file__).parent / "sample_report.json"
     output_path.write_text(report.model_dump_json(indent=2))
     print(f"Sample report written to {output_path}")

--- a/examples/sample_report.json
+++ b/examples/sample_report.json
@@ -1,7 +1,7 @@
 {
   "run_metadata": {
     "tool_version": "0.1.0",
-    "timestamp": "2026-02-25T07:53:21.657402Z",
+    "timestamp": "2026-02-25T16:28:15.003893Z",
     "command": "constraintguard run --source examples/vuln_demo --build-cmd 'make' --config examples/configs/tight.yml --out out/demo",
     "source_path": "examples/vuln_demo",
     "config_path": "examples/configs/tight.yml"


### PR DESCRIPTION
Closes #7

## What Changed

### Explanation Generator (`reporting/explanation.py`)
- **`build_explanation(vuln, spec, base_score, final_score, firings)`** converts rule traces into a single prose paragraph per finding
  - Opens with finding type + exact location (file, line, function)
  - States the embedded-specific consequence of that category (e.g. ARM HardFault for null_deref, heap exhaustion for leak)
  - Phrases "why it's risky for this constraint profile" using the actual fired-rule rationales combined into a single `because X; Y; and Z.` sentence
  - Falls back to a constraint-context sentence (actual KB/µs values) when no rules fired

### Remediation Templates (`reporting/remediation.py`)
- **`build_remediation(category, spec)`** returns embedded-appropriate guidance for all 10 vulnerability categories
  - Base templates cover the general fix pattern (e.g. strncpy, pool allocators, lock ordering)
  - `_constraint_addendum` appends a constraint-specific sentence when the profile matches: tight stack → MPU canary advice; tight heap → pool allocator recommendation; safety level → MISRA C callout; ISR latency + deadlock → interrupt budget warning
  - `spec=None` supported for callers without a hardware profile

### Constraints Summary (`reporting/constraints_summary.py`)
- **`build_constraints_summary_lines(spec, provenance)`** emits the profile block shown at the top of every report: platform, safety level, RAM/Flash/Stack/Heap, IRQ latency, critical functions, and provenance source paths

### Console Renderer (`reporting/console.py`)
- **`print_report_to_console(report, top_k=10)`** renders a complete self-contained report to stdout without needing to open any file
  - Run header (timestamp, source, config)
  - Constraints summary block
  - Severity distribution with proportional bar chart
  - Top-K findings each showing: tier + score, location, wrapped explanation paragraph, wrapped remediation, fired rule IDs with deltas

### Wiring
- engine.py — removed inline templates and old `_build_explanation`/`_build_remediation`; now delegates to the reporting layer, passing `spec` so remediations are constraint-aware
- __init__.py — exports the four public functions
- mock_pipeline.py — calls `print_report_to_console` before writing JSON so a single `python examples/mock_pipeline.py` demonstrates the full D6 output